### PR TITLE
🛠🐛💣 [Bug Fix] (config) Remove step about running shell to check release type.

### DIFF
--- a/.github/workflows/push_pkg_to_pypi.yaml
+++ b/.github/workflows/push_pkg_to_pypi.yaml
@@ -51,11 +51,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Download shell script for checking input parameters
-        run: |
-          curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/check_getting_output.sh --output ./scripts/ci/check_getting_output.sh
-          bash ./scripts/ci/check_getting_output.sh
-
       - name: Setup Python 3.10 in Ubuntu OS
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
### _Target_

* Remove step about running shell to check release type.


### _Modify Code Scope_

* The directory _.github/workflows_ of GitHub Action workflows configurations.


### _Effecting Scope_

* Nothing, fix issue of workflow pushing Python package PyPI.


### _Description_

* Remove step about running shell _check_getting_output.sh_.
