### PR TITLE
🛠🐛💣 [Bug Fix] Fix the broken CI process because coverage report file is hidden file.

### DIFF
--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -61,6 +61,7 @@ jobs:
           name: test_coverage_data_file
           path: .coverage
           if-no-files-found: error
+          include-hidden-files: true
 
       - name: Upload testing coverage report (.xml)
         uses: actions/upload-artifact@v3

--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -68,3 +68,4 @@ jobs:
           name: test_coverage_xml_report
           path: coverage**xml
           if-no-files-found: error
+          include-hidden-files: true

--- a/.github/workflows/rw_poetry_run_test.yaml
+++ b/.github/workflows/rw_poetry_run_test.yaml
@@ -133,5 +133,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: .coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
+          path: ./.coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
           if-no-files-found: error

--- a/.github/workflows/rw_poetry_run_test.yaml
+++ b/.github/workflows/rw_poetry_run_test.yaml
@@ -135,3 +135,4 @@ jobs:
           name: coverage
           path: ./.coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
           if-no-files-found: error
+          include-hidden-files: true

--- a/.github/workflows/rw_poetry_run_test.yaml
+++ b/.github/workflows/rw_poetry_run_test.yaml
@@ -122,7 +122,9 @@ jobs:
         continue-on-error: true
 
       - name: Rename the code coverage result file
-        run: mv ./.coverage ./.coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
+        run: |
+          ls -la
+          mv ./.coverage ./.coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
 
       - name: Upload code coverage result file
         uses: actions/upload-artifact@v3

--- a/.github/workflows/rw_poetry_run_test.yaml
+++ b/.github/workflows/rw_poetry_run_test.yaml
@@ -123,8 +123,11 @@ jobs:
 
       - name: Rename the code coverage result file
         run: |
+          echo "Before rename file ..."
           ls -la
           mv ./.coverage ./.coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
+          echo "After rename file ..."
+          ls -la
 
       - name: Upload code coverage result file
         uses: actions/upload-artifact@v3

--- a/.github/workflows/rw_poetry_run_test.yaml
+++ b/.github/workflows/rw_poetry_run_test.yaml
@@ -123,16 +123,12 @@ jobs:
 
       - name: Rename the code coverage result file
         run: |
-          echo "Before rename file ..."
-          ls -la
           mv ./.coverage ./.coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
-          echo "After rename file ..."
-          ls -la
 
       - name: Upload code coverage result file
         uses: actions/upload-artifact@v3
         with:
           name: coverage
-          path: ./.coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
+          path: .coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
           if-no-files-found: error
           include-hidden-files: true

--- a/.github/workflows/rw_run_test.yaml
+++ b/.github/workflows/rw_run_test.yaml
@@ -121,3 +121,4 @@ jobs:
           name: coverage
           path: .coverage.${{ inputs.test_type }}.${{ inputs.runtime_os }}-${{ inputs.python_version }}
           if-no-files-found: error
+          include-hidden-files: true


### PR DESCRIPTION
### _Target_

* Fix the broken CI process because coverage report file is hidden file.


### _Effecting Scope_

* All CI processes includes the usage in other projects.


### _Description_

* Add setting parameter `include-hidden-files` at all usages of CI processes which are ready to upload coverage report to Action Artifact.
