### PR TITLE
🤖⚙️🔧 [Improvement] Let CI/CD supports more detail version info to release.

### DIFF
--- a/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
@@ -75,7 +75,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download shell script for checking input parameters
-        run: curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/build_git-tag_or_create_github-release.sh --output ./scripts/ci/build_git-tag_or_create_github-release.sh
+        run: |
+          curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/build_git-tag_or_create_github-release.sh --output ./scripts/ci/build_git-tag_or_create_github-release.sh
+          curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/generate_release_info.sh --output ./scripts/ci/generate_release_info.sh
 
       # This flow for the project type is Python project
       - name: Build git tag and create GitHub release for Python project
@@ -97,10 +99,8 @@ jobs:
         if: ${{ inputs.project_type == 'github-action-reusable-workflow' }}
         id: github_action_reusable_workflow_release
         run: | 
-          release=$(bash ./scripts/ci/build_git-tag_or_create_github-release.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
-          echo "📄 Release log: $release"
-
-          release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,})|(Pre\-Release))")
+          release_info=$(bash ./scripts/ci/generate_release_info.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
+          release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 
           echo "release_version=$(echo $release_version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
@@ -100,7 +100,7 @@ jobs:
         id: github_action_reusable_workflow_release
         run: | 
           release_info=$(bash ./scripts/ci/generate_release_info.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
-          release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,})|(Pre\-Release))")
+          release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 
           echo "release_version=$(echo $release_version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
@@ -100,10 +100,9 @@ jobs:
         id: github_action_reusable_workflow_release
         run: | 
           release_info=$(bash ./scripts/ci/generate_release_info.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
-          release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))")
+          release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 
           echo "release_version=$(echo $release_version)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.github_auth_token }}
-

--- a/scripts/ci/build_git-tag_or_create_github-release.sh
+++ b/scripts/ci/build_git-tag_or_create_github-release.sh
@@ -180,6 +180,7 @@ generate_new_version_as_tag() {
         if [ "$current_ver" == "" ]; then
             current_ver=0
         fi
+        # TODO: Modify the logic about it also can get the version from the specific file
         New_Release_Version=$(( current_ver + 1 ))
         New_Release_Tag='v'$New_Release_Version'.0.0'
     fi

--- a/scripts/ci/generate_release_info.sh
+++ b/scripts/ci/generate_release_info.sh
@@ -5,4 +5,13 @@ release=$(bash ./scripts/ci/build_git-tag_or_create_github-release.sh "$Input_Ar
 echo "📄 Release log: $release"
 
 release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))")
+is_first_release_version=$(echo "$release_version" | grep -E -o "([0-9]{1,}\.0\.{0,1}0{0,1})")
+if [ "$is_first_release_version" != "" ]; then
+    # shellcheck disable=SC2125
+    # shellcheck disable=SC2207
+    # shellcheck disable=SC2034
+    release_version_array=($(echo "$release_version" | grep -E -o "([0-9]{1,})"))
+    # shellcheck disable=SC2125
+    release_version="${release_version_array[0]}"
+fi
 echo " 📲 Target version which would be pass to deployment process: $release_version"

--- a/scripts/ci/generate_release_info.sh
+++ b/scripts/ci/generate_release_info.sh
@@ -1,0 +1,8 @@
+Input_Arg_Project_Type=$1
+Input_Arg_Debug_Mode=$2
+
+release=$(bash ./scripts/ci/build_git-tag_or_create_github-release.sh "$Input_Arg_Project_Type" "$Input_Arg_Debug_Mode")
+echo "📄 Release log: $release"
+
+release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,})|(Pre\-Release))")
+echo " 📲 Target version which would be pass to deployment process: $release_version"

--- a/scripts/ci/generate_release_info.sh
+++ b/scripts/ci/generate_release_info.sh
@@ -4,5 +4,5 @@ Input_Arg_Debug_Mode=$2
 release=$(bash ./scripts/ci/build_git-tag_or_create_github-release.sh "$Input_Arg_Project_Type" "$Input_Arg_Debug_Mode")
 echo "📄 Release log: $release"
 
-release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,})|(Pre\-Release))")
+release_version=$(echo "$release" | grep -E "\[GitHub Action - Reusable workflow\] \[Final Running Result\] (Official\-Release and version: ([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.[0-9]{1,})|(Pre\-Release))")
 echo " 📲 Target version which would be pass to deployment process: $release_version"

--- a/scripts/ci/generate_release_info.sh
+++ b/scripts/ci/generate_release_info.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 Input_Arg_Project_Type=$1
 Input_Arg_Debug_Mode=$2
 


### PR DESCRIPTION
### _Target_

* Let CI/CD supports more detail version info to release.
    * It may just adjust minor something which is not major changes. So it won't need to release as major version.
    * as is:
        version could be semi-version format but the git tag and git branch always be `vX`, e.g., `v6`.
    * to be:
        version could be semi-version format, git tag and git branch also could be as `v7` or `v7.2`.


### _Effecting Scope_

* Nothing, just effect the result by the version info.


### _Description_

* Modify the shell script about parsing and generating the version info from the release info files.
* Modify the CI/CD process details to support releasing with detail version info.
