### PR TITLE
🛠🐛💣 [Bug Fix] Fix the broken CI process about cannot finely parsing and generating version info when it's pre-release tag.

### DIFF
--- a/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
@@ -101,7 +101,7 @@ jobs:
         run: | 
           release_info=$(bash ./scripts/ci/generate_release_info.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
           echo "🧾 release_info: $release_info"
-          release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))")
+          release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: (([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 
           echo "release_version=$(echo $release_version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
@@ -100,6 +100,7 @@ jobs:
         id: github_action_reusable_workflow_release
         run: | 
           release_info=$(bash ./scripts/ci/generate_release_info.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
+          echo "[DEBUG] release_info: $release_info"
           release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 

--- a/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
+++ b/.github/workflows/rw_build_git-tag_and_create_github-release.yaml
@@ -100,7 +100,7 @@ jobs:
         id: github_action_reusable_workflow_release
         run: | 
           release_info=$(bash ./scripts/ci/generate_release_info.sh ${{ inputs.project_type }} ${{ inputs.debug_mode }})
-          echo "[DEBUG] release_info: $release_info"
+          echo "🧾 release_info: $release_info"
           release_version=$(echo "$release_info" | grep -E "Target version which would be pass to deployment process: ([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))" | grep -E -o "(([0-9]{1,}\.{0,1}[0-9]{0,}\.{0,1}[0-9]{0,})|(Pre\-Release))")
           echo "🤖 Release Version: $release_version"
 


### PR DESCRIPTION
### _Target_

* Fix the broken CI process about cannot finely parsing and generating version info when it's pre-release tag.


### _Effecting Scope_

* CI/CD of GitHub Action reusable workflow project. Let it could work finely.


### _Description_

* Modify the regular expression about parsing the version info which for release checking.
