### PR TITLE
[CU-86et1f25t] Improve the reusable workflow about running test with option about installing dependency without different group

### DIFF
--- a/.github/workflows/rw_poetry_run_test.yaml
+++ b/.github/workflows/rw_poetry_run_test.yaml
@@ -52,6 +52,11 @@ on:
         type: string
         required: false
         default: ''
+      install_dependency_without_group:
+        description: "Install the dependency by Poetry configuration without dependency group setting. This parameter receive the dependency group naming."
+        type: string
+        required: false
+        default: ''
       all_test_items_paths:
         description: "The target paths of test items under test."
         required: true
@@ -125,6 +130,11 @@ jobs:
         if: ${{ inputs.install_dependency_with_group != '' }}
         run: |
           poetry install --with=${{ inputs.install_dependency_with_group }}
+
+      - name: Build Python runtime environment by Poetry with dependency group *${{ inputs.install_dependency_without_group }}*
+        if: ${{ inputs.install_dependency_without_group != '' }}
+        run: |
+          poetry install --without=${{ inputs.install_dependency_without_group }}
 
       - name: Setup and run HTTP server for testing
         if: ${{ inputs.setup_http_server == true }}

--- a/.github/workflows/rw_poetry_run_test.yaml
+++ b/.github/workflows/rw_poetry_run_test.yaml
@@ -120,10 +120,11 @@ jobs:
           pip install -U flask
           pip install -U gunicorn
           pip install -U poetry
+          poetry --version
 
       - name: Build Python runtime environment by Poetry
+        if: ${{ inputs.install_dependency_with_group != '' || inputs.install_dependency_without_group != '' }}
         run: |
-          poetry --version
           poetry install
 
       - name: Build Python runtime environment by Poetry with dependency group *${{ inputs.install_dependency_with_group }}*
@@ -131,7 +132,7 @@ jobs:
         run: |
           poetry install --with=${{ inputs.install_dependency_with_group }}
 
-      - name: Build Python runtime environment by Poetry with dependency group *${{ inputs.install_dependency_without_group }}*
+      - name: Build Python runtime environment by Poetry without dependency group *${{ inputs.install_dependency_without_group }}*
         if: ${{ inputs.install_dependency_without_group != '' }}
         run: |
           poetry install --without=${{ inputs.install_dependency_without_group }}


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Improve the reusable workflow about running test with option about installing dependency without different group.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86et1f25t.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    N/A.


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Add new parameter of reusable workflow without breaking changes.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Add new parameter of reusable workflow about installing Python dependency without specific group settings.
