### PR TITLE
[CU-86etc7mv5] Remove deprecated field in GitHub dependency bot and add new configuration about code owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# CODEOWNERS file for GitHub Action Reusable Workflows Python project
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo
+*                           @Chisanan232
+
+# Workflow files
+/.github/workflows/         @Chisanan232
+
+# Scripts directory
+/scripts/                   @Chisanan232
+
+# Test files
+/test/                      @Chisanan232
+
+# CI/CD configuration
+/.github/                   @Chisanan232
+
+# Core project files
+/pyproject.toml             @Chisanan232
+/poetry.lock                @Chisanan232
+/setup.py                   @Chisanan232
+
+# Documentation
+/README.md                  @Chisanan232
+/LICENSE                    @Chisanan232
+
+# Configuration files
+/.coveragerc                @Chisanan232
+/pytest.ini                 @Chisanan232
+/sonar-project.properties   @Chisanan232

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "Chisanan232"
     labels:
       - "🔍 enhancement"
       - "🤖 github actions"


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Remove deprecated field in GitHub dependency bot and add new configuration about code owners.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86etc7mv5.
    * Relative task IDs:
        * N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/.
    <img width="927" alt="Screenshot 2025-05-06 at 12 03 06 PM" src="https://github.com/user-attachments/assets/da23db3b-378f-4345-8452-3433e7807f98" />


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Adjust the configuration only.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Remove the deprecated field `reviewers` in GitHub dependency bot configuration.
* Add a new configuration about code owners.
