### PR TITLE
[CU-86ex529dn] 🧑‍💻 ci: Enhance monorepo release orchestrator with multi-stage support and full parameter passing

### DIFF
--- a/.github/workflows/rw_monorepo_release_orchestrator.yaml
+++ b/.github/workflows/rw_monorepo_release_orchestrator.yaml
@@ -6,6 +6,7 @@
 # Features:
 # - Automatic change detection via git diff
 # - Parallel or sequential package releases
+# - Multi-stage support: production, staging, validation
 # - Intent.yaml configuration integration
 # - Package dependency management (future)
 #
@@ -13,6 +14,7 @@
 #   1. Manual trigger: Select packages to release
 #   2. Scheduled: Detect and release changed packages
 #   3. PR merge: Release packages modified in PR
+#   4. Stage selection: Choose production, staging, or validation workflow
 
 name: Monorepo Release Orchestrator
 
@@ -33,6 +35,11 @@ on:
         description: 'Release mode: parallel or sequential'
         required: false
         default: 'sequential'
+        type: string
+      release-stage:
+        description: 'Release stage: production, staging, or validation'
+        required: false
+        default: 'production'
         type: string
       dry-run:
         description: 'Dry run mode - show what would be released without actually releasing'
@@ -213,11 +220,11 @@ jobs:
             echo "  (none)"
           fi
 
-  # Step 4: Release packages (matrix strategy)
-  release-packages:
-    name: Release ${{ matrix.package }}
+  # Step 4a: Production Release
+  release-packages-production:
+    name: Release ${{ matrix.package }} (Production)
     needs: [prepare-releases]
-    if: ${{ needs.prepare-releases.outputs.release_count > 0 && !inputs.dry-run }}
+    if: ${{ needs.prepare-releases.outputs.release_count > 0 && !inputs.dry-run && inputs.release-stage == 'production' }}
     strategy:
       max-parallel: ${{ inputs.release-mode == 'sequential' && 1 || 10 }}
       fail-fast: false
@@ -232,10 +239,43 @@ jobs:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
+  # Step 4b: Staging Release
+  release-packages-staging:
+    name: Release ${{ matrix.package }} (Staging)
+    needs: [prepare-releases]
+    if: ${{ needs.prepare-releases.outputs.release_count > 0 && !inputs.dry-run && inputs.release-stage == 'staging' }}
+    strategy:
+      max-parallel: ${{ inputs.release-mode == 'sequential' && 1 || 10 }}
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.prepare-releases.outputs.release_packages) }}
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_release_staging_complete.yaml@master
+    with:
+      package-name: ${{ matrix.package }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+
+  # Step 4c: Validation Release
+  release-packages-validation:
+    name: Validate ${{ matrix.package }}
+    needs: [prepare-releases]
+    if: ${{ needs.prepare-releases.outputs.release_count > 0 && !inputs.dry-run && inputs.release-stage == 'validation' }}
+    strategy:
+      max-parallel: ${{ inputs.release-mode == 'sequential' && 1 || 10 }}
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.prepare-releases.outputs.release_packages) }}
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_release_validation_complete.yaml@master
+    with:
+      package-name: ${{ matrix.package }}
+
   # Step 5: Summarize results
   summarize:
     name: Release Summary
-    needs: [prepare-releases, release-packages]
+    needs: [prepare-releases, release-packages-production, release-packages-staging, release-packages-validation]
     if: always()
     runs-on: ubuntu-latest
     outputs:
@@ -248,7 +288,11 @@ jobs:
         env:
           RELEASE_COUNT: ${{ needs.prepare-releases.outputs.release_count }}
           RELEASE_PACKAGES: ${{ needs.prepare-releases.outputs.release_packages }}
+          RELEASE_STAGE: ${{ inputs.release-stage }}
           DRY_RUN: ${{ inputs.dry-run }}
+          PRODUCTION_RESULT: ${{ needs.release-packages-production.result }}
+          STAGING_RESULT: ${{ needs.release-packages-staging.result }}
+          VALIDATION_RESULT: ${{ needs.release-packages-validation.result }}
         run: |
           echo "## Monorepo Release Orchestrator Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -259,6 +303,7 @@ jobs:
             echo "🚀 **Mode**: Live Release" >> $GITHUB_STEP_SUMMARY
           fi
           
+          echo "🎯 **Stage**: $RELEASE_STAGE" >> $GITHUB_STEP_SUMMARY
           echo "📊 **Packages to release**: $RELEASE_COUNT" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
@@ -268,8 +313,24 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             
             if [ "$DRY_RUN" = "false" ]; then
+              # Determine which job result to check based on stage
+              case "$RELEASE_STAGE" in
+                production)
+                  RESULT="$PRODUCTION_RESULT"
+                  ;;
+                staging)
+                  RESULT="$STAGING_RESULT"
+                  ;;
+                validation)
+                  RESULT="$VALIDATION_RESULT"
+                  ;;
+                *)
+                  RESULT="skipped"
+                  ;;
+              esac
+              
               # Check if all releases succeeded
-              if [ "${{ needs.release-packages.result }}" = "success" ]; then
+              if [ "$RESULT" = "success" ]; then
                 echo "✅ All package releases completed successfully!" >> $GITHUB_STEP_SUMMARY
                 echo "all_successful=true" >> $GITHUB_OUTPUT
               else

--- a/.github/workflows/rw_monorepo_release_orchestrator.yaml
+++ b/.github/workflows/rw_monorepo_release_orchestrator.yaml
@@ -40,6 +40,20 @@ on:
         default: false
         type: boolean
     
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'DockerHub username'
+        required: false
+      DOCKERHUB_TOKEN:
+        description: 'DockerHub access token'
+        required: false
+      PYPI_API_TOKEN:
+        description: 'PyPI API token (required for token-based authentication)'
+        required: false
+      TEST_PYPI_API_TOKEN:
+        description: 'Test PyPI API token (required for token-based authentication)'
+        required: false
+    
     outputs:
       packages-released:
         description: 'JSON array of packages that were released'
@@ -204,18 +218,19 @@ jobs:
     name: Release ${{ matrix.package }}
     needs: [prepare-releases]
     if: ${{ needs.prepare-releases.outputs.release_count > 0 && !inputs.dry-run }}
-    runs-on: ubuntu-latest
     strategy:
       max-parallel: ${{ inputs.release-mode == 'sequential' && 1 || 10 }}
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.prepare-releases.outputs.release_packages) }}
-    steps:
-      - name: Release package
-        uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_release_complete.yaml@master
-        with:
-          package-name: ${{ matrix.package }}
-        secrets: inherit
+    uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_release_complete.yaml@master
+    with:
+      package-name: ${{ matrix.package }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
   # Step 5: Summarize results
   summarize:

--- a/.github/workflows/rw_monorepo_release_orchestrator.yaml
+++ b/.github/workflows/rw_monorepo_release_orchestrator.yaml
@@ -41,6 +41,31 @@ on:
         required: false
         default: 'production'
         type: string
+      level:
+        description: 'Release level (auto, patch, minor, major)'
+        required: false
+        default: 'auto'
+        type: string
+      python:
+        description: 'Python package release (auto, force, skip)'
+        required: false
+        default: 'auto'
+        type: string
+      docker:
+        description: 'Docker image release (auto, force, skip)'
+        required: false
+        default: 'auto'
+        type: string
+      docs:
+        description: 'Documentation versioning (auto, force, skip)'
+        required: false
+        default: 'auto'
+        type: string
+      notes:
+        description: 'Release notes'
+        required: false
+        default: ''
+        type: string
       dry-run:
         description: 'Dry run mode - show what would be released without actually releasing'
         required: false
@@ -233,6 +258,11 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_release_complete.yaml@master
     with:
       package-name: ${{ matrix.package }}
+      level: ${{ inputs.level }}
+      python: ${{ inputs.python }}
+      docker: ${{ inputs.docker }}
+      docs: ${{ inputs.docs }}
+      notes: ${{ inputs.notes }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -252,6 +282,7 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_release_staging_complete.yaml@master
     with:
       package-name: ${{ matrix.package }}
+      level: ${{ inputs.level }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -271,6 +302,10 @@ jobs:
     uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_release_validation_complete.yaml@master
     with:
       package-name: ${{ matrix.package }}
+      level: ${{ inputs.level }}
+      python: ${{ inputs.python }}
+      docker: ${{ inputs.docker }}
+      docs: ${{ inputs.docs }}
 
   # Step 5: Summarize results
   summarize:


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Enhance the monorepo release orchestrator to support multiple release stages (production, staging, validation) and pass all relevant input parameters to downstream workflows. This also fixes the secret inheritance issue that was causing CI failures.

* ### Task tickets:

    * Task ID: N/A.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    **Before:**
    - Orchestrator only supported production releases
    - Used `secrets: inherit` which is invalid for reusable workflows
    - Only passed `package-name` to downstream workflows
    
    **After:**
    - Supports three release stages: production, staging, validation
    - Explicitly passes all required secrets
    - Passes all relevant parameters (level, python, docker, docs, notes) to workflows


## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [x] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [x] ⚙️ Reusable workflow
        * [ ] 🐍 Scripts
        * [ ] 🗃️ Configuration
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 End-to-end testing
    * [x] 📚 Documentation
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
* Additional description:
    This PR includes three main improvements to the monorepo release orchestrator workflow.


## _Description_

### 1. Fix Secret Inheritance Issue (Commit: 2674341)
**Problem:** The orchestrator was using `secrets: inherit` when calling reusable workflows, which is invalid and caused CI failures with error: "Unexpected value 'secrets'".

**Solution:**
- Added explicit `secrets` declaration in `workflow_call` inputs
- Changed from `secrets: inherit` to explicitly passing each secret:
  - `DOCKERHUB_USERNAME`
  - `DOCKERHUB_TOKEN`
  - `PYPI_API_TOKEN`
  - `TEST_PYPI_API_TOKEN`
- Moved `uses` from step level to job level (required for reusable workflow calls)

### 2. Multi-Stage Release Support (Commit: b06ac0e)
**Enhancement:** Added support for different release stages to enable flexible CI/CD pipelines.

**Changes:**
- Added `release-stage` input parameter with options: `production`, `staging`, `validation`
- Split release job into three conditional jobs:
  - `release-packages-production`: Calls `rw_release_complete.yaml`
  - `release-packages-staging`: Calls `rw_release_staging_complete.yaml`
  - `release-packages-validation`: Calls `rw_release_validation_complete.yaml`
- Updated summary job to handle all three stages
- Enhanced workflow documentation

**Benefits:**
- Single orchestrator for all release stages
- Enables validation → staging → production pipelines
- Validation stage doesn't require secrets
- Backward compatible (defaults to production)

### 3. Full Parameter Passing (Commit: 402a441)
**Enhancement:** Pass all relevant input parameters to downstream workflows for complete control.

**Added Parameters:**
- `level`: Release level (auto, patch, minor, major)
- `python`: Python package control (auto, force, skip)
- `docker`: Docker image control (auto, force, skip)
- `docs`: Documentation control (auto, force, skip)
- `notes`: Release notes text

**Parameter Support Matrix:**
| Parameter | Production | Staging | Validation |
|-----------|-----------|---------|------------|
| `level` | ✅ | ✅ | ✅ |
| `python` | ✅ | ❌ | ✅ |
| `docker` | ✅ | ❌ | ✅ |
| `docs` | ✅ | ❌ | ✅ |
| `notes` | ✅ | ❌ | ❌ |

**Benefits:**
- Callers can control version bumps
- Can force or skip specific release types
- Can add custom release notes
- Each workflow receives only supported parameters

### 4. Documentation
Added comprehensive guide at `.ai/prompt/2026.4.12/monorepo-orchestrator-multi-stage-guide.md` with:
- Usage examples for all three stages
- Advanced configuration examples
- Parameter reference table
- Migration guide from previous version
- Complete CI/CD pipeline example

### Testing Recommendations
- ✅ Test production release with default parameters
- ✅ Test staging release with custom level
- ✅ Test validation without secrets
- ✅ Test parameter passing (force python, skip docker)
- ✅ Test sequential vs parallel modes
- ✅ Test auto-detection of changed packages

### Breaking Changes
None. All changes are backward compatible with sensible defaults.