### PR TITLE
🐛 ci: Fix path concatenation in organize coverage workflow

### DIFF
--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_data_file', inputs.project_name, inputs.test_type) || format('{0}_coverage_data_file', inputs.test_type) }}
-          path: ${{ inputs.test_working_directory }}.coverage
+          path: ${{ inputs.test_working_directory }}/.coverage
           if-no-files-found: error
           include-hidden-files: true
 
@@ -91,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_xml_report', inputs.project_name, inputs.test_type) || format('{0}_coverage_xml_report', inputs.test_type) }}
-          path: ${{ inputs.test_working_directory }}coverage**xml
+          path: ${{ inputs.test_working_directory }}/coverage**xml
           if-no-files-found: error
           include-hidden-files: true


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix path concatenation bugs in the organize coverage workflow that prevent coverage files from being found and uploaded correctly.

* ### Task tickets:

    * Task ID: N/A
    * Relative task IDs:
        * [ ] N/A
    * Relative PRs:
        * #146 (merged) - Fixed test workflow path concatenation

* ### Key point change (optional):

    Fixed upload paths to properly concatenate directory and filename with explicit slash separator.

## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [x] ⚙️ Reusable workflow
        * [ ] 🐍 Scripts
        * [ ] 🗃️ Configuration
    * [ ] 🎨 UI/UX
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
    * [x] 📚 Documentation
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations

## _Description_

### Problem

The organize coverage workflow was failing to find and upload coverage files with error:
```
No source for code: '/Users/runner/work/test-coverage-mcp/test-coverage-mcp/src/__init__.py'
Error: Process completed with exit code 1.
```

The upload paths were missing slash separators, similar to the bug fixed in #146.

### Root Cause

The upload paths were constructed using string concatenation without a separator:

**Line 86** (.coverage file):
```yaml
# BEFORE (broken):
path: ${{ inputs.test_working_directory }}.coverage

# When test_working_directory = "./test-coverage-mcp"
# Result: "./test-coverage-mcp.coverage" ❌
```

**Line 94** (XML file):
```yaml
# BEFORE (broken):
path: ${{ inputs.test_working_directory }}coverage**xml

# When test_working_directory = "./test-coverage-mcp"  
# Result: "./test-coverage-mcpcoverage**xml" ❌
```

### Solution

Added explicit slash separators in both paths:

**Line 86** (.coverage file):
```yaml
# AFTER (fixed):
path: ${{ inputs.test_working_directory }}/.coverage

# Result: "./test-coverage-mcp/.coverage" ✅
```

**Line 94** (XML file):
```yaml
# AFTER (fixed):
path: ${{ inputs.test_working_directory }}/coverage**xml

# Result: "./test-coverage-mcp/coverage**xml" ✅
```

### Why This Matters

This bug prevented the organize workflow from finding the combined coverage files to upload:

**Before Fix:**
1. Coverage files combined successfully ✅
2. Upload looks for `.coverage` at wrong path ❌
3. Upload fails - file not found ❌
4. XML upload fails - file not found ❌
5. Coverage reports never reach downstream jobs ❌

**After Fix:**
1. Coverage files combined successfully ✅
2. Upload looks for `.coverage` at correct path ✅
3. Upload succeeds - file found and uploaded ✅
4. XML upload succeeds - file found and uploaded ✅
5. Coverage reports reach SonarQube/Codecov ✅

### Related Fixes

This is the **same path concatenation bug pattern** that was fixed in:
- #146 - Test workflow (`rw_uv_run_test.yaml`)
  - Fixed upload path (line 225)
  - Fixed check path (line 248)

Now fixing in:
- This PR - Organize workflow (`rw_organize_test_cov_reports.yaml`)
  - Fixed .coverage upload path (line 86)
  - Fixed XML upload path (line 94)

### Testing

This fix should be tested with:
- ✅ Monorepo projects with `test_working_directory` set to subdirectory
- ✅ Single-repo projects with `test_working_directory` = `./`
- ✅ Verify `.coverage` file is uploaded correctly
- ✅ Verify coverage XML files are uploaded correctly
- ✅ Verify downstream tools can access coverage reports

### Breaking Changes

None. This is a pure bug fix that makes the workflow work as originally intended.