### PR TITLE
✨ ci: Add graceful skip when no coverage files exist in organize workflow

### DIFF
--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -2,6 +2,9 @@
 #
 # Workflow Description:
 #     Organize all the testing coverage reports. (it would save reports by 'actions/upload-artifact').
+#     
+#     Note: This workflow gracefully skips if no coverage files are found (e.g., when tests were skipped).
+#     This prevents failures when packages have no tests or when test execution was skipped.
 #
 # Workflow input parameters:
 #     * test_type: The testing type. In generally, it only has 2 options: 'unit-test' and 'integration-test'.
@@ -52,17 +55,34 @@ jobs:
 
       - name: Download code coverage result file
         uses: actions/download-artifact@v8
+        continue-on-error: true
+        id: download_coverage
         with:
           pattern: ${{ inputs.project_name != '' && format('coverage_{0}*', inputs.project_name) || 'coverage*' }}
           path: ${{ inputs.test_working_directory }}
           merge-multiple: true
 
+      - name: Check if coverage files exist
+        id: check_coverage
+        working-directory: ${{ inputs.test_working_directory }}
+        run: |
+          if ls .coverage.* 1> /dev/null 2>&1; then
+            echo "has_coverage=true" >> $GITHUB_OUTPUT
+            echo "✅ Coverage files found"
+            ls -la .coverage.*
+          else
+            echo "has_coverage=false" >> $GITHUB_OUTPUT
+            echo "⏭️ No coverage files found - skipping coverage organization"
+          fi
+
       - name: Setup Python ${{ inputs.run_with_python_version }} in Ubuntu OS
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.run_with_python_version }}
 
       - name: Install Python tool 'coverage'
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           python3 -m pip install --upgrade pip
@@ -72,6 +92,7 @@ jobs:
           ls -la
 
       - name: Combine all testing coverage data files with test type and runtime OS, and convert to XML format file finally
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           mkdir -p ./scripts/ci/
@@ -80,17 +101,19 @@ jobs:
           bash ./scripts/ci/combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
 
       - name: Upload testing coverage report (.coverage)
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_data_file', inputs.project_name, inputs.test_type) || format('{0}_coverage_data_file', inputs.test_type) }}
           path: ${{ inputs.test_working_directory }}/.coverage
-          if-no-files-found: error
+          if-no-files-found: warn
           include-hidden-files: true
 
       - name: Upload testing coverage report (.xml)
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_xml_report', inputs.project_name, inputs.test_type) || format('{0}_coverage_xml_report', inputs.test_type) }}
           path: ${{ inputs.test_working_directory }}/coverage**xml
-          if-no-files-found: error
+          if-no-files-found: warn
           include-hidden-files: true


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Add graceful skip logic to the organize coverage workflow to prevent failures when no coverage files exist (e.g., when tests were skipped or packages have no tests).

* ### Task tickets:

    * Task ID: N/A
    * Relative task IDs:
        * [ ] N/A
    * Relative PRs:
        * #146 (merged) - Fixed test workflow path bugs
        * #147 (merged) - Fixed organize workflow path bugs

* ### Key point change (optional):

    Added coverage file existence check before processing to gracefully skip when no coverage artifacts are available.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [x] 🍀 Improving something
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [x] ⚙️ Reusable workflow
        * [ ] 🐍 Scripts
        * [ ] 🗃️ Configuration
    * [ ] 🎨 UI/UX
    * [x] ⛑️ Error handling
    * [ ] 🧪 Testing
    * [x] 📚 Documentation
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations

## _Description_

### Problem

The organize coverage workflow runs even when no coverage files exist, causing unnecessary failures:

**Scenario 1: Package with no tests (e.g., codecov package)**
```
✅ Tests skipped (no tests found)
✅ No coverage files uploaded
❌ organize job runs anyway → FAILS with "No coverage files found"
```

**Scenario 2: Package with tests but no coverage config**
```
✅ Tests run successfully
✅ No coverage files generated (no pytest --cov config)
❌ organize job runs anyway → FAILS with "Couldn't combine from non-existent path"
```

### Root Cause

The organize workflow (`rw_organize_test_cov_reports.yaml`) was missing the graceful skip logic that was previously added to the `develop` branch but not yet on `master`.

The workflow would:
1. Download artifacts (might find nothing)
2. Try to combine coverage files (fails if none exist)
3. Fail the entire job ❌

### Solution

Added comprehensive coverage existence checking and conditional processing:

**1. Download with error tolerance (Lines 54-60)**:
```yaml
- name: Download code coverage result file
  continue-on-error: true  # Don't fail if no artifacts
  id: download_coverage
```

**2. Check for coverage files (Lines 62-73)**:
```yaml
- name: Check if coverage files exist
  id: check_coverage
  run: |
    if ls .coverage.* 1> /dev/null 2>&1; then
      echo "has_coverage=true" >> $GITHUB_OUTPUT
      echo "✅ Coverage files found"
    else
      echo "has_coverage=false" >> $GITHUB_OUTPUT
      echo "⏭️ No coverage files found - skipping"
    fi
```

**3. Conditional processing (Lines 75-116)**:
```yaml
- name: Setup Python
  if: steps.check_coverage.outputs.has_coverage == 'true'
  
- name: Install coverage tool
  if: steps.check_coverage.outputs.has_coverage == 'true'
  
- name: Combine coverage
  if: steps.check_coverage.outputs.has_coverage == 'true'
  
- name: Upload .coverage
  if: steps.check_coverage.outputs.has_coverage == 'true'
  
- name: Upload XML
  if: steps.check_coverage.outputs.has_coverage == 'true'
```

**4. Error handling improvement**:
```yaml
# Changed from:
if-no-files-found: error

# To:
if-no-files-found: warn
```

### Workflow Behavior

**Before Fix**:
```
Package without tests (codecov):
  ✅ Test job: Skipped
  ❌ Organize job: Runs and FAILS
  ❌ Upload job: Skipped (dependency failed)
  ❌ CI shows RED! ❌
```

**After Fix**:
```
Package without tests (codecov):
  ✅ Test job: Skipped (has-coverage=false)
  ✅ Organize job: Skipped (no coverage files)
  ✅ Upload job: Skipped (dependency skipped)
  ✅ CI shows GREEN! ✅
```

**For packages WITH coverage**:
```
Package with tests and coverage (core):
  ✅ Test job: Success (has-coverage=true)
  ✅ Organize job: Runs and succeeds
  ✅ Upload job: Runs and succeeds
  ✅ CI shows GREEN! ✅
```

### Impact on Monorepo Workflows

This is especially important for monorepo projects where:
- Some packages may have tests, others may not
- Some packages may be in early development without test coverage config
- Test coverage configuration is managed per-package (via pytest.ini or pyproject.toml)

**Example: test-coverage-mcp monorepo**
- `test-coverage-mcp` package: Has tests, has coverage ✅
- `test-coverage-mcp-codecov` package: No tests yet ✅
- Previously: codecov package caused CI failures ❌
- Now: Both packages process cleanly ✅

### Related Changes

This completes the coverage workflow fix chain:

**PR #146 (Merged)** - Test Workflow (`rw_uv_run_test.yaml`)
- Fixed upload path concatenation
- Fixed coverage check path concatenation  
- Added missing parameter
- Set `has-coverage` output correctly

**PR #147 (Merged)** - Organize Workflow (`rw_organize_test_cov_reports.yaml`)
- Fixed .coverage upload path concatenation
- Fixed XML upload path concatenation

**This PR #148** - Organize Workflow (`rw_organize_test_cov_reports.yaml`)
- Add graceful skip logic
- Check coverage file existence
- Conditional processing
- Improved error handling

### Documentation Updates

Updated workflow header documentation to explain graceful skip behavior:
```yaml
# Note: This workflow gracefully skips if no coverage files are found 
# (e.g., when tests were skipped). This prevents failures when packages 
# have no tests or when test execution was skipped.
```

### Testing

This should be tested with:
- ✅ Monorepo with mixed packages (some with tests, some without)
- ✅ Package with tests but no coverage configuration
- ✅ Package with no tests directory
- ✅ Verify organize job skips gracefully when appropriate
- ✅ Verify coverage processing works normally when files exist

### Breaking Changes

None. This is a pure improvement that makes the workflow more robust and prevents false failures.

### Benefits

✅ No more false failures for packages without tests  
✅ Cleaner CI output in monorepos  
✅ Consistent with test workflow behavior (PR #146)  
✅ Better error messages and logging  
✅ Allows gradual addition of test coverage  
✅ Supports packages in early development  

The organize workflow now properly handles all scenarios! 🎉