### PR TITLE
♻️ ci: Simplify coverage script download - remove unnecessary folder structure

### DIFF
--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -95,10 +95,9 @@ jobs:
         if: steps.check_coverage.outputs.has_coverage == 'true'
         working-directory: ${{ inputs.test_working_directory }}
         run: |
-          mkdir -p ./scripts/ci/
-          echo "Download shell script for combining coverage reports ..."
-          curl https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh --output ./scripts/ci/combine_coverage_reports.sh
-          bash ./scripts/ci/combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
+          echo "Downloading coverage combine script..."
+          curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh
+          bash combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
 
       - name: Upload testing coverage report (.coverage)
         if: steps.check_coverage.outputs.has_coverage == 'true'


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Simplify the coverage combine script download by eliminating unnecessary folder structure creation. Since the script is dynamically downloaded at runtime and only used temporarily, it doesn't need to recreate the repository's folder structure.

* ### Task tickets:

    * Task ID: N/A
    * Relative task IDs:
        * [ ] N/A
    * Relative PRs:
        * #146 (merged) - Fixed test workflow path bugs
        * #147 (merged) - Fixed organize workflow path bugs  
        * #148 (merged) - Added graceful skip logic

* ### Key point change (optional):

    Download script directly to working directory instead of creating `./scripts/ci/` folder structure.

## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [x] ♻️ Refactoring something
    * [x] 🍀 Improving something
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [x] ⚙️ Reusable workflow
        * [ ] 🐍 Scripts
        * [ ] 🗃️ Configuration
    * [ ] 🎨 UI/UX
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
    * [ ] 📚 Documentation
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations

## _Description_

### Current Approach (Unnecessarily Complex)

```yaml
working-directory: ${{ inputs.test_working_directory }}
run: |
  mkdir -p ./scripts/ci/                    # Creating nested folders
  echo "Download shell script for combining coverage reports ..."
  curl https://raw.githubusercontent.com/.../combine_coverage_reports.sh --output ./scripts/ci/combine_coverage_reports.sh
  bash ./scripts/ci/combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
```

**Issues**:
- Creates unnecessary folder structure (`./scripts/ci/`)
- More complex than needed for a temporary runtime download
- The script is only used once and discarded
- Doesn't need to mirror the repository's folder structure

### New Approach (Simplified)

```yaml
working-directory: ${{ inputs.test_working_directory }}
run: |
  echo "Downloading coverage combine script..."
  curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/.../combine_coverage_reports.sh
  bash combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
```

**Benefits**:
✅ No folder creation needed  
✅ Script downloaded directly to working directory (where coverage files are)  
✅ Cleaner and simpler  
✅ Added curl flags for better reliability:
- `-f` Fail silently on server errors
- `-s` Silent mode (no progress bar)
- `-S` Show errors even in silent mode
- `-L` Follow redirects

✅ Minimal footprint  
✅ Still easy to debug if needed (file is visible in working directory)

### Rationale

The script is **dynamically downloaded at runtime** for temporary use:
1. Downloaded from repository at CI runtime
2. Used to combine coverage files
3. Discarded after workflow completes

Since it's temporary, there's no need to recreate the `./scripts/ci/` folder structure from the repository. The script should simply be placed where it's most convenient to operate - **in the working directory where the coverage files exist**.

### Changes Made

**File**: `.github/workflows/rw_organize_test_cov_reports.yaml` (Lines 94-100)

**Before**:
```yaml
run: |
  mkdir -p ./scripts/ci/
  echo "Download shell script for combining coverage reports ..."
  curl https://...combine_coverage_reports.sh --output ./scripts/ci/combine_coverage_reports.sh
  bash ./scripts/ci/combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
```

**After**:
```yaml
run: |
  echo "Downloading coverage combine script..."
  curl -fsSL -o combine_coverage_reports.sh https://...combine_coverage_reports.sh
  bash combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
```

**Line count**: Reduced from 5 lines to 3 lines ✅

### Technical Details

**Why this works**:
- `working-directory` is already set to `${{ inputs.test_working_directory }}`
- Coverage files (`.coverage.*`) are in this directory
- Script needs to operate on these files
- Download script to same directory = most convenient and correct

**curl flags explained**:
- `-f, --fail`: Fail silently on HTTP errors (returns non-zero exit code)
- `-s, --silent`: Silent mode, no progress meter
- `-S, --show-error`: Show errors even when -s is used
- `-L, --location`: Follow redirects if any
- `-o <file>`: Write output to file

### Impact

**Before**:
```
test-coverage-mcp/
  ├── .coverage.unit-test.ubuntu-latest-3.12
  ├── .coverage.unit-test.macos-latest-3.12
  └── scripts/              ← Created unnecessarily
      └── ci/
          └── combine_coverage_reports.sh
```

**After**:
```
test-coverage-mcp/
  ├── .coverage.unit-test.ubuntu-latest-3.12
  ├── .coverage.unit-test.macos-latest-3.12
  └── combine_coverage_reports.sh    ← Simple, direct
```

### Testing

No functional changes - the script still:
- Downloads from the same source
- Executes in the same working directory
- Operates on the same coverage files
- Produces the same outputs

This is purely a refactoring to simplify the download mechanism.

### Related Context

This improvement was suggested based on the observation that:
> "The script is dynamically downloaded in the CI runtime environment, so it doesn't need to be saved in a specific folder structure like `./scripts/ci/`. Just put it in a path where it can correctly and conveniently operate."

This aligns with the principle of **simplicity** - don't create unnecessary structure for temporary runtime artifacts.

### Breaking Changes

None. This is a pure refactoring that maintains identical functionality with a simpler implementation.

### Benefits

✅ Simpler code - easier to understand and maintain  
✅ Fewer operations - faster execution  
✅ Cleaner working directory structure  
✅ More reliable with curl flags  
✅ Still debuggable (script visible if issues occur)  
✅ Follows best practices for temporary runtime downloads