### PR TITLE
🐛 ci: Comment out coverage report command that causes errors

### DIFF
--- a/scripts/ci/combine_coverage_reports.sh
+++ b/scripts/ci/combine_coverage_reports.sh
@@ -14,7 +14,7 @@ else
   coverage combine --data-file="$coveragedatafile" "$test_coverage_report_format$test_type"*
 fi
 
-coverage report -m --data-file="$coveragedatafile"
+# coverage report -m --data-file="$coveragedatafile"
 coverage xml --data-file="$coveragedatafile" -o coverage_"$test_type".xml
 cp "$coveragedatafile" .coverage
 echo "✅ All processing done." && exit 0


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Temporarily disable the `coverage report -m` command that causes "No source for code" errors in CI, while keeping XML generation working.

* ### Task tickets:

    * Task ID: N/A
    * Relative PRs:
        * #150 (merged) - Added source code verification and debug steps

## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something
    * [ ] 🚀 Release
* Scopes:
    * [x] 🐍 Scripts
    * [x] 🤖 CI/CD

## _Description_

### Problem

The `coverage report -m` command fails with:
```
No source for code: '/Users/runner/work/.../src/__init__.py'
Error: Process completed with exit code 1.
```

This causes the entire organize coverage job to fail.

### Solution

Comment out the problematic command:

**Before**:
```bash
coverage report -m --data-file="$coveragedatafile"
coverage xml --data-file="$coveragedatafile" -o coverage_"$test_type".xml
```

**After**:
```bash
# coverage report -m --data-file="$coveragedatafile"
coverage xml --data-file="$coveragedatafile" -o coverage_"$test_type".xml
```

### Impact

- ❌ **Disabled**: Text coverage report in CI logs
- ✅ **Working**: Coverage combine (generates `.coverage` file)
- ✅ **Working**: XML generation (needed for SonarQube/Codecov)
- ✅ **Working**: Coverage data upload

### Why This Works

The `coverage report -m` command is **not critical** - it only prints a text report to the console for debugging. The important parts are:
1. `coverage combine` - Combines coverage data ✅ (still working)
2. `coverage xml` - Generates XML for upload ✅ (still working)
3. `.coverage` file copy ✅ (still working)

This is a **temporary workaround** while we investigate the root cause of the missing source files issue.

### Breaking Changes

None - this only removes debug output, not functionality.