### PR TITLE
🔧 ci: Use master branch for script download instead of develop

### DIFF
--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -117,7 +117,7 @@ jobs:
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           echo "Downloading coverage combine script..."
-          curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh
+          curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
           bash combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
 
       - name: Debug coverage paths


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix incorrect branch reference in script download URL - use `master` instead of `develop` to ensure stable, tested script version is used.

* ### Task tickets:

    * Task ID: N/A
    * Relative PRs:
        * #149 (merged) - Simplified script download
        * #150 (merged) - Added verification and debug steps
        * #151 (merged) - Commented out coverage report command

## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [x] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something
    * [ ] 🚀 Release
* Scopes:
    * [x] ⚙️ Reusable workflow
    * [x] 🤖 CI/CD

## _Description_

### Problem

The organize coverage workflow downloads the `combine_coverage_reports.sh` script from the **`develop`** branch:

```yaml
curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/.../develop/scripts/ci/combine_coverage_reports.sh
```

This is inconsistent because:
1. The workflow itself is called with `@master` reference
2. The `develop` branch may contain untested or unstable changes
3. Users expect stable behavior from workflows on `master`

### Solution

Change the download URL to use **`master`** branch:

**Before**:
```yaml
curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh
```

**After**:
```yaml
curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
```

### Rationale

**Consistency**: When users call the workflow with:
```yaml
uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_organize_test_cov_reports.yaml@master
```

They expect **all** components to come from the `master` branch, not a mix of `master` and `develop`.

**Stability**: The `master` branch contains tested, stable code. The `develop` branch may have:
- Work in progress
- Untested changes
- Breaking changes

**Predictability**: Users should get consistent behavior. Mixing branches can cause unexpected issues.

### Impact

✅ **Stable script version**: Always uses the tested version from `master`  
✅ **Consistency**: Workflow and script from same branch  
✅ **Predictability**: No surprises from develop branch changes  
✅ **Reliability**: Reduced risk of CI failures from unstable scripts

### Testing

No functional changes - just using a different branch reference. The script content on `master` is the same (with the coverage report fix from PR #151).

### Breaking Changes

None. This ensures the workflow uses the stable script version as users would expect.