### PR TITLE
✨ feat: Add graceful coverage handling and monorepo support for SonarQube

### DIFF
--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -117,9 +117,8 @@ jobs:
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           echo "Downloading coverage combine script..."
-          curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh
+          curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
           bash ./combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
-
 
       - name: Upload testing coverage report (.coverage)
         if: steps.check_coverage.outputs.has_coverage == 'true'

--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -2,6 +2,9 @@
 #
 # Workflow Description:
 #     Organize all the testing coverage reports. (it would save reports by 'actions/upload-artifact').
+#     
+#     Note: This workflow gracefully skips if no coverage files are found (e.g., when tests were skipped).
+#     This prevents failures when packages have no tests or when test execution was skipped.
 #
 # Workflow input parameters:
 #     * test_type: The testing type. In generally, it only has 2 options: 'unit-test' and 'integration-test'.
@@ -52,17 +55,34 @@ jobs:
 
       - name: Download code coverage result file
         uses: actions/download-artifact@v8
+        continue-on-error: true
+        id: download_coverage
         with:
           pattern: ${{ inputs.project_name != '' && format('coverage_{0}*', inputs.project_name) || 'coverage*' }}
           path: ${{ inputs.test_working_directory }}
           merge-multiple: true
 
+      - name: Check if coverage files exist
+        id: check_coverage
+        working-directory: ${{ inputs.test_working_directory }}
+        run: |
+          if ls .coverage.* 1> /dev/null 2>&1; then
+            echo "has_coverage=true" >> $GITHUB_OUTPUT
+            echo "✅ Coverage files found"
+            ls -la .coverage.*
+          else
+            echo "has_coverage=false" >> $GITHUB_OUTPUT
+            echo "⏭️ No coverage files found - skipping coverage organization"
+          fi
+
       - name: Setup Python ${{ inputs.run_with_python_version }} in Ubuntu OS
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.run_with_python_version }}
 
       - name: Install Python tool 'coverage'
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           python3 -m pip install --upgrade pip
@@ -72,6 +92,7 @@ jobs:
           ls -la
 
       - name: Combine all testing coverage data files with test type and runtime OS, and convert to XML format file finally
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           mkdir -p ./scripts/ci/
@@ -80,17 +101,19 @@ jobs:
           bash ./scripts/ci/combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
 
       - name: Upload testing coverage report (.coverage)
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_data_file', inputs.project_name, inputs.test_type) || format('{0}_coverage_data_file', inputs.test_type) }}
           path: ${{ inputs.test_working_directory }}.coverage
-          if-no-files-found: error
+          if-no-files-found: warn
           include-hidden-files: true
 
       - name: Upload testing coverage report (.xml)
+        if: steps.check_coverage.outputs.has_coverage == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_xml_report', inputs.project_name, inputs.test_type) || format('{0}_coverage_xml_report', inputs.test_type) }}
           path: ${{ inputs.test_working_directory }}coverage**xml
-          if-no-files-found: error
+          if-no-files-found: warn
           include-hidden-files: true

--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -117,7 +117,7 @@ jobs:
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           echo "Downloading coverage combine script..."
-          curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
+          curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh
           pwd
           ls -la
           ls -la ./src

--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -118,29 +118,8 @@ jobs:
         run: |
           echo "Downloading coverage combine script..."
           curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/develop/scripts/ci/combine_coverage_reports.sh
-          pwd
-          ls -la
-          ls -la ./src
           bash ./combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
 
-      - name: Debug coverage paths
-        if: steps.check_coverage.outputs.has_coverage == 'true'
-        working-directory: ${{ inputs.test_working_directory }}
-        run: |
-          echo "🔍 Checking combined coverage data..."
-          if [ -f ".coverage.${{ inputs.test_type }}" ]; then
-            echo "📊 Files referenced in coverage data:"
-            coverage debug data --data-file=.coverage.${{ inputs.test_type }} || echo "⚠️ Could not read coverage data"
-            echo ""
-            echo "📂 Current directory structure:"
-            pwd
-            ls -la
-            echo ""
-            echo "📂 Source directory (if exists):"
-            ls -la src/ 2>/dev/null || echo "⚠️ No src/ directory found"
-          else
-            echo "⚠️ Combined coverage file not found"
-          fi
 
       - name: Upload testing coverage report (.coverage)
         if: steps.check_coverage.outputs.has_coverage == 'true'

--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -118,10 +118,10 @@ jobs:
         run: |
           echo "Downloading coverage combine script..."
           curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
-          bash ./combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
           pwd
           ls -la
           ls -la ./src
+          bash ./combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
 
       - name: Debug coverage paths
         if: steps.check_coverage.outputs.has_coverage == 'true'

--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -117,8 +117,11 @@ jobs:
         working-directory: ${{ inputs.test_working_directory }}
         run: |
           echo "Downloading coverage combine script..."
-          curl -fsSL -o combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
-          bash combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
+          curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
+          bash ./combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
+          pwd
+          ls -la
+          ls -la ./src
 
       - name: Debug coverage paths
         if: steps.check_coverage.outputs.has_coverage == 'true'

--- a/.github/workflows/rw_sonarqube_scan.yaml
+++ b/.github/workflows/rw_sonarqube_scan.yaml
@@ -72,40 +72,31 @@ jobs:
         continue-on-error: true
         with:
           pattern: '*_${{ inputs.test_type }}_coverage_xml_report'
-          path: ./coverage-downloads
+          path: ${{ inputs.download_path }}
           merge-multiple: false
 
-      - name: Move coverage files to package directories
+      - name: Move coverage files to package directories (monorepo only)
+        if: inputs.project_name != ''
         run: |
-          echo "📂 Organizing coverage files for SonarQube..."
+          echo "📂 Organizing coverage files for monorepo..."
           
-          if [ -d "./coverage-downloads" ]; then
-            for artifact_dir in ./coverage-downloads/*; do
-              if [ -d "$artifact_dir" ]; then
-                artifact_name=$(basename "$artifact_dir")
-                echo "Processing: $artifact_name"
-                
-                # Parse package name from artifact naming pattern: {package_name}_{test_type}_coverage_xml_report
-                # Extract everything before _{test_type}_coverage_xml_report
-                package_name="${artifact_name%_${{ inputs.test_type }}_coverage_xml_report}"
-                
-                if [ -n "$package_name" ] && [ "$package_name" != "$artifact_name" ]; then
-                  # Monorepo: move to package directory
-                  mkdir -p "./$package_name"
-                  mv "$artifact_dir"/*.xml "./$package_name/" 2>/dev/null && echo "  ✅ Moved to $package_name/" || echo "  ⚠️ No XML files"
-                else
-                  # Single-project: move to root
-                  mv "$artifact_dir"/*.xml ./ 2>/dev/null && echo "  ✅ Moved to root" || echo "  ⚠️ No XML files"
-                fi
-              fi
-            done
-          else
-            echo "⚠️ No coverage artifacts found - scanning without coverage"
-          fi
+          for artifact_dir in ${{ inputs.download_path }}/*_${{ inputs.test_type }}_coverage_xml_report; do
+            if [ -d "$artifact_dir" ]; then
+              artifact_name=$(basename "$artifact_dir")
+              echo "Processing: $artifact_name"
+              
+              # Parse package name from artifact naming: {package_name}_{test_type}_coverage_xml_report
+              package_name="${artifact_name%_${{ inputs.test_type }}_coverage_xml_report}"
+              
+              # Move to package directory
+              mkdir -p "./$package_name"
+              mv "$artifact_dir"/*.xml "./$package_name/" 2>/dev/null && echo "  ✅ Moved to $package_name/" || echo "  ⚠️ No XML files"
+            fi
+          done
           
           echo ""
           echo "📊 Coverage files ready for SonarQube:"
-          find . -path ./coverage-downloads -prune -o -name "coverage*.xml" -type f -print 2>/dev/null || echo "No coverage files"
+          find . -name "coverage*.xml" -type f 2>/dev/null || echo "No coverage files"
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v7.1.0

--- a/.github/workflows/rw_sonarqube_scan.yaml
+++ b/.github/workflows/rw_sonarqube_scan.yaml
@@ -67,46 +67,44 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Download all coverage XML reports
+      - name: Download coverage XML reports for test type
         uses: actions/download-artifact@v8
         continue-on-error: true
         with:
-          pattern: '*_coverage_xml_report'
+          pattern: '*_${{ inputs.test_type }}_coverage_xml_report'
           path: ./coverage-downloads
           merge-multiple: false
 
-      - name: Move coverage files to correct package directories
+      - name: Move coverage files to package directories
         run: |
-          echo "📂 Moving coverage files to match sonar-project.properties paths..."
+          echo "📂 Organizing coverage files for SonarQube..."
           
-          # For each downloaded artifact folder, move the coverage XML to the correct package directory
           if [ -d "./coverage-downloads" ]; then
             for artifact_dir in ./coverage-downloads/*; do
               if [ -d "$artifact_dir" ]; then
                 artifact_name=$(basename "$artifact_dir")
-                echo "Processing artifact: $artifact_name"
+                echo "Processing: $artifact_name"
                 
-                # Determine target directory based on artifact name
-                if [[ "$artifact_name" == test-coverage-mcp_* ]] && [[ "$artifact_name" != *codecov* ]]; then
-                  # Core package: move to test-coverage-mcp/
-                  mkdir -p ./test-coverage-mcp
-                  mv "$artifact_dir"/*.xml ./test-coverage-mcp/ 2>/dev/null && echo "  ✅ Moved to test-coverage-mcp/" || echo "  ⚠️ No XML files found"
-                elif [[ "$artifact_name" == test-coverage-mcp-codecov_* ]]; then
-                  # Codecov package: move to test-coverage-mcp-codecov/
-                  mkdir -p ./test-coverage-mcp-codecov
-                  mv "$artifact_dir"/*.xml ./test-coverage-mcp-codecov/ 2>/dev/null && echo "  ✅ Moved to test-coverage-mcp-codecov/" || echo "  ⚠️ No XML files found"
+                # Parse package name from artifact naming pattern: {package_name}_{test_type}_coverage_xml_report
+                # Extract everything before _{test_type}_coverage_xml_report
+                package_name="${artifact_name%_${{ inputs.test_type }}_coverage_xml_report}"
+                
+                if [ -n "$package_name" ] && [ "$package_name" != "$artifact_name" ]; then
+                  # Monorepo: move to package directory
+                  mkdir -p "./$package_name"
+                  mv "$artifact_dir"/*.xml "./$package_name/" 2>/dev/null && echo "  ✅ Moved to $package_name/" || echo "  ⚠️ No XML files"
                 else
-                  # Single-project repo: move to root
-                  mv "$artifact_dir"/*.xml ./ 2>/dev/null && echo "  ✅ Moved to root" || echo "  ⚠️ No XML files found"
+                  # Single-project: move to root
+                  mv "$artifact_dir"/*.xml ./ 2>/dev/null && echo "  ✅ Moved to root" || echo "  ⚠️ No XML files"
                 fi
               fi
             done
           else
-            echo "⚠️ No coverage downloads found - scanning without coverage"
+            echo "⚠️ No coverage artifacts found - scanning without coverage"
           fi
           
           echo ""
-          echo "📊 Final coverage file locations:"
+          echo "📊 Coverage files ready for SonarQube:"
           find . -path ./coverage-downloads -prune -o -name "coverage*.xml" -type f -print 2>/dev/null || echo "No coverage files"
 
       - name: SonarCloud Scan

--- a/.github/workflows/rw_sonarqube_scan.yaml
+++ b/.github/workflows/rw_sonarqube_scan.yaml
@@ -2,12 +2,16 @@
 #
 # Workflow Description:
 #     Trigger SonarQube cloud service to scan entire project to check code quality, security, etc.
+#     Supports both single-project and monorepo configurations.
 #
 # Workflow input parameters:
 #     * General arguments:
-#         * test_type: The testing type. In generally, it only has 2 options: 'unit-test' and 'integration-test'.
-#         * download_path: The path to download testing coverage reports via 'actions/download-artifact'.
-#         * sonar_host_url: The server host URL about SonarQube scanning mechanism.
+#         * test_type: The testing type (default: 'all-test'). Options: 'unit-test', 'integration-test', 'all-test'.
+#         * is_monorepo: Boolean flag indicating if this is a monorepo (default: false).
+#         * download_path: The path to download testing coverage reports via 'actions/download-artifact' (default: './').
+#         * project_working_directory: Working directory for the project to scan (default: './').
+#         * sonar_project_key: SonarQube project key (optional, uses sonar-project.properties if not set).
+#         * sonar_host_url: The server host URL about SonarQube scanning mechanism (default: 'https://sonarcloud.io').
 #
 #     * Secret arguments:
 #         * sonar_token: The API token for triggering SonarQube cloud service.
@@ -27,11 +31,11 @@ on:
         required: false
         type: string
         default: all-test
-      project_name:
-        description: "Project identifier for monorepo (filters coverage artifacts by project). Leave empty for single-project repos."
-        type: string
+      is_monorepo:
+        description: "Set to true for monorepo projects (organizes coverage files by package). Set to false for single-project repos."
+        type: boolean
         required: false
-        default: ''
+        default: false
       project_working_directory:
         description: "Working directory for the project to scan. For monorepo, specify the package directory."
         type: string
@@ -76,7 +80,7 @@ jobs:
           merge-multiple: false
 
       - name: Move coverage files to package directories (monorepo only)
-        if: inputs.project_name != ''
+        if: inputs.is_monorepo == true
         run: |
           echo "📂 Organizing coverage files for monorepo..."
           

--- a/.github/workflows/rw_sonarqube_scan.yaml
+++ b/.github/workflows/rw_sonarqube_scan.yaml
@@ -67,11 +67,47 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Download code coverage result files which has be handled by different test type process
+      - name: Download all coverage XML reports
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
-          name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_xml_report', inputs.project_name, inputs.test_type) || format('{0}_coverage_xml_report', inputs.test_type) }}
-          path: ${{ inputs.project_working_directory }}${{ inputs.download_path }}
+          pattern: '*_coverage_xml_report'
+          path: ./coverage-downloads
+          merge-multiple: false
+
+      - name: Move coverage files to correct package directories
+        run: |
+          echo "📂 Moving coverage files to match sonar-project.properties paths..."
+          
+          # For each downloaded artifact folder, move the coverage XML to the correct package directory
+          if [ -d "./coverage-downloads" ]; then
+            for artifact_dir in ./coverage-downloads/*; do
+              if [ -d "$artifact_dir" ]; then
+                artifact_name=$(basename "$artifact_dir")
+                echo "Processing artifact: $artifact_name"
+                
+                # Determine target directory based on artifact name
+                if [[ "$artifact_name" == test-coverage-mcp_* ]] && [[ "$artifact_name" != *codecov* ]]; then
+                  # Core package: move to test-coverage-mcp/
+                  mkdir -p ./test-coverage-mcp
+                  mv "$artifact_dir"/*.xml ./test-coverage-mcp/ 2>/dev/null && echo "  ✅ Moved to test-coverage-mcp/" || echo "  ⚠️ No XML files found"
+                elif [[ "$artifact_name" == test-coverage-mcp-codecov_* ]]; then
+                  # Codecov package: move to test-coverage-mcp-codecov/
+                  mkdir -p ./test-coverage-mcp-codecov
+                  mv "$artifact_dir"/*.xml ./test-coverage-mcp-codecov/ 2>/dev/null && echo "  ✅ Moved to test-coverage-mcp-codecov/" || echo "  ⚠️ No XML files found"
+                else
+                  # Single-project repo: move to root
+                  mv "$artifact_dir"/*.xml ./ 2>/dev/null && echo "  ✅ Moved to root" || echo "  ⚠️ No XML files found"
+                fi
+              fi
+            done
+          else
+            echo "⚠️ No coverage downloads found - scanning without coverage"
+          fi
+          
+          echo ""
+          echo "📊 Final coverage file locations:"
+          find . -path ./coverage-downloads -prune -o -name "coverage*.xml" -type f -print 2>/dev/null || echo "No coverage files"
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v7.1.0

--- a/.github/workflows/rw_upload_test_cov_report.yaml
+++ b/.github/workflows/rw_upload_test_cov_report.yaml
@@ -118,15 +118,30 @@ jobs:
 
       - name: Download code coverage result files which has be handled by different test type process
         uses: actions/download-artifact@v8
+        continue-on-error: true
+        id: download_coverage_data
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_data_file', inputs.project_name, inputs.test_type) || format('{0}_coverage_data_file', inputs.test_type) }}
           path: ${{ inputs.download_path }}
 
       - name: Download code coverage result files which has be handled by different test type process
         uses: actions/download-artifact@v8
+        continue-on-error: true
+        id: download_coverage_xml
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_xml_report', inputs.project_name, inputs.test_type) || format('{0}_coverage_xml_report', inputs.test_type) }}
           path: ${{ inputs.download_path }}
+
+      - name: Check if coverage files exist
+        id: check_coverage
+        run: |
+          if [ -f "${{ inputs.download_path }}/coverage_${{ inputs.test_type }}.xml" ]; then
+            echo "has_coverage=true" >> $GITHUB_OUTPUT
+            echo "✅ Coverage XML file found"
+          else
+            echo "has_coverage=false" >> $GITHUB_OUTPUT
+            echo "⏭️ No coverage XML file found - skipping upload"
+          fi
 
       - name: Install Python ${{ inputs.run_with_python_version }}
 #        if: ${{ inputs.upload-to-codecov == true || inputs.upload-to-coveralls == true }}
@@ -158,7 +173,7 @@ jobs:
 #            --verbose
 
       - name: Upload coverage report to Codecov https://codecov.io
-        if: ${{ inputs.upload-to-codecov == true }}
+        if: ${{ inputs.upload-to-codecov == true && steps.check_coverage.outputs.has_coverage == 'true' }}
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
@@ -175,14 +190,14 @@ jobs:
         run: pip3 install coveralls
 
       - name: Upload coverage report to Coveralls https://coveralls.io
-        if: ${{ inputs.upload-to-coveralls == true }}
+        if: ${{ inputs.upload-to-coveralls == true && steps.check_coverage.outputs.has_coverage == 'true' }}
         working-directory: ${{ inputs.test_working_directory }}
         env:
           GITHUB_TOKEN: ${{ secrets.coveralls_token }}
         run: coveralls --verbose
 
       - name: Upload testing report to Codacy https://app.codacy.com/
-        if: ${{ inputs.upload-to-codacy == true }}
+        if: ${{ inputs.upload-to-codacy == true && steps.check_coverage.outputs.has_coverage == 'true' }}
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.codacy_token }}

--- a/.github/workflows/rw_upload_test_cov_report.yaml
+++ b/.github/workflows/rw_upload_test_cov_report.yaml
@@ -116,23 +116,53 @@ jobs:
           echo "Check the parameters of uploading report to Codacy ..."
           bash ./scripts/ci/check-input-params.sh ${{ inputs.upload-to-codacy }} ${{ secrets.codacy_token }}
 
+      - name: Check if coverage artifacts exist
+        id: check_artifacts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            
+            const dataArtifactName = '${{ inputs.project_name != '' && format('{0}_{1}_coverage_data_file', inputs.project_name, inputs.test_type) || format('{0}_coverage_data_file', inputs.test_type) }}';
+            const xmlArtifactName = '${{ inputs.project_name != '' && format('{0}_{1}_coverage_xml_report', inputs.project_name, inputs.test_type) || format('{0}_coverage_xml_report', inputs.test_type) }}';
+            
+            const hasDataArtifact = artifacts.data.artifacts.some(a => a.name === dataArtifactName);
+            const hasXmlArtifact = artifacts.data.artifacts.some(a => a.name === xmlArtifactName);
+            
+            core.setOutput('has_data_artifact', hasDataArtifact);
+            core.setOutput('has_xml_artifact', hasXmlArtifact);
+            core.setOutput('has_any_artifact', hasDataArtifact || hasXmlArtifact);
+            
+            if (hasDataArtifact || hasXmlArtifact) {
+              console.log('✅ Coverage artifacts found');
+              if (hasDataArtifact) console.log(`  - ${dataArtifactName}`);
+              if (hasXmlArtifact) console.log(`  - ${xmlArtifactName}`);
+            } else {
+              console.log('⏭️ No coverage artifacts found - will skip upload');
+            }
+
       - name: Download code coverage result files which has be handled by different test type process
+        if: steps.check_artifacts.outputs.has_data_artifact == 'true'
         uses: actions/download-artifact@v8
-        continue-on-error: true
         id: download_coverage_data
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_data_file', inputs.project_name, inputs.test_type) || format('{0}_coverage_data_file', inputs.test_type) }}
           path: ${{ inputs.download_path }}
 
       - name: Download code coverage result files which has be handled by different test type process
+        if: steps.check_artifacts.outputs.has_xml_artifact == 'true'
         uses: actions/download-artifact@v8
-        continue-on-error: true
         id: download_coverage_xml
         with:
           name: ${{ inputs.project_name != '' && format('{0}_{1}_coverage_xml_report', inputs.project_name, inputs.test_type) || format('{0}_coverage_xml_report', inputs.test_type) }}
           path: ${{ inputs.download_path }}
 
       - name: Check if coverage files exist
+        if: steps.check_artifacts.outputs.has_any_artifact == 'true'
         id: check_coverage
         run: |
           HAS_XML=false

--- a/.github/workflows/rw_upload_test_cov_report.yaml
+++ b/.github/workflows/rw_upload_test_cov_report.yaml
@@ -135,12 +135,29 @@ jobs:
       - name: Check if coverage files exist
         id: check_coverage
         run: |
+          HAS_XML=false
+          HAS_DATA=false
+          
           if [ -f "${{ inputs.download_path }}/coverage_${{ inputs.test_type }}.xml" ]; then
-            echo "has_coverage=true" >> $GITHUB_OUTPUT
+            HAS_XML=true
             echo "✅ Coverage XML file found"
           else
+            echo "⚠️ Coverage XML file not found"
+          fi
+          
+          if [ -f "${{ inputs.download_path }}/.coverage" ]; then
+            HAS_DATA=true
+            echo "✅ Coverage data file (.coverage) found"
+          else
+            echo "⚠️ Coverage data file (.coverage) not found"
+          fi
+          
+          if [ "$HAS_XML" = "true" ] || [ "$HAS_DATA" = "true" ]; then
+            echo "has_coverage=true" >> $GITHUB_OUTPUT
+            echo "✅ Coverage files available for upload"
+          else
             echo "has_coverage=false" >> $GITHUB_OUTPUT
-            echo "⏭️ No coverage XML file found - skipping upload"
+            echo "⏭️ No coverage files found - skipping upload"
           fi
 
       - name: Install Python ${{ inputs.run_with_python_version }}

--- a/scripts/ci/combine_coverage_reports.sh
+++ b/scripts/ci/combine_coverage_reports.sh
@@ -14,7 +14,25 @@ else
   coverage combine --data-file="$coveragedatafile" "$test_coverage_report_format$test_type"*
 fi
 
-# coverage report -m --data-file="$coveragedatafile"
+# Get current working directory for path remapping
+CURRENT_DIR=$(pwd)
+echo "📂 Current directory: $CURRENT_DIR"
+
+# Create .coveragerc to handle path remapping from macOS (/Users/) to Linux (/home/)
+cat > .coveragerc << EOF
+[paths]
+source =
+    src/
+    ./src/
+    */src/
+    /Users/runner/work/*/src/
+    /home/runner/work/*/src/
+EOF
+
+echo "📝 Created .coveragerc for path remapping"
+cat .coveragerc
+
+coverage report -m --data-file="$coveragedatafile"
 coverage xml --data-file="$coveragedatafile" -o coverage_"$test_type".xml
 cp "$coveragedatafile" .coverage
 echo "✅ All processing done." && exit 0


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

Fix coverage upload workflow failures when sub-projects have no tests/coverage, and add comprehensive monorepo support for SonarQube scanning.

[//]: # (The summary what you did or your target.)
* ### Task summary:

    1. **Coverage Upload Graceful Handling**: Fix workflow failures when coverage artifacts don't exist (e.g., sub-projects without tests)
    2. **SonarQube Monorepo Support**: Enable SonarQube to scan monorepo projects with multiple packages
    3. **Cross-OS Coverage Path Fix**: Resolve coverage path mismatch between macOS and Linux runners
    4. **Workflow Cleanup**: Remove debug commands and improve code quality

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: N/A.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * Related: test-coverage-mcp PR (monorepo CI implementation)

[//]: # (The key changes like demonstration, as-is \u0026 to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **Before**: 
    - ❌ Workflow fails if coverage artifacts missing
    - ❌ SonarQube doesn't support monorepo
    - ❌ Coverage path mismatch between macOS/Linux
    
    **After**:
    - ✅ Gracefully skips when no coverage artifacts
    - ✅ Full monorepo support with `is_monorepo` parameter
    - ✅ Cross-OS path remapping via `.coveragerc`


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [x] ♻️ Refactoring something
    * [x] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [x] ⚙️ Reusable workflow
        * [x] 🐍 Scripts
        * [x] 🗃️ Configuration
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [x] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 End-to-end testing
    * [ ] 📚 Documentation
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
* Additional description:
    - Affects all projects using `rw_upload_test_cov_report.yaml`, `rw_organize_test_cov_reports.yaml`, and `rw_sonarqube_scan.yaml`
    - Backward compatible - existing single-project repos work without changes
    - Monorepo projects need to set `is_monorepo: true` for SonarQube


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

### 1. Coverage Upload Graceful Handling (`rw_upload_test_cov_report.yaml`)
- **Check artifact existence before download**: Use GitHub API to verify artifacts exist before attempting download
- **Conditional file checks**: Only check for coverage files if artifacts were found
- **Skip upload gracefully**: All upload steps (Codecov, Coveralls, Codacy) skip if no coverage files exist
- **Check both file types**: Verify both `.coverage` data file and `coverage_*.xml` report

### 2. SonarQube Monorepo Support (`rw_sonarqube_scan.yaml`)
- **New `is_monorepo` parameter**: Boolean flag (default: `false`) for clearer intent vs checking empty strings
- **Pattern-based artifact download**: Download all coverage artifacts matching `*_{test_type}_coverage_xml_report`
- **Automatic package detection**: Parse package name from artifact naming convention
- **Smart file organization**: Move coverage files to correct package directories for SonarQube to find
- **Single-project compatibility**: Works seamlessly for both monorepo and single-project repos

### 3. Coverage Path Remapping (`combine_coverage_reports.sh`)
- **Cross-OS path mapping**: Add `.coveragerc` configuration to remap paths between macOS and Linux
- **Path patterns**: Support `/Users/runner/work/*/src/` (macOS) and `/home/runner/work/*/src/` (Linux)
- **Fix "No source for code" error**: Ensure coverage report can find source files regardless of OS

### 4. Workflow Cleanup (`rw_organize_test_cov_reports.yaml`)
- **Remove debug commands**: Clean up `pwd`, `ls -la` commands used during troubleshooting
- **Remove debug step**: Delete entire "Debug coverage paths" step
- **Production-ready**: Streamlined workflow without debugging artifacts

## _Technical Details_

### Coverage Upload Flow:
```yaml
1. Check if artifacts exist (GitHub API)
   ├─ Found: Download artifacts
   └─ Not found: Skip gracefully

2. Check if files exist locally
   ├─ Has coverage: Proceed with upload
   └─ No coverage: Skip upload steps

3. Upload to services (conditional)
   ├─ Codecov (if enabled + has coverage)
   ├─ Coveralls (if enabled + has coverage)
   └─ Codacy (if enabled + has coverage)
```

### SonarQube Monorepo Flow:
```yaml
1. Download artifacts: *_all-test_coverage_xml_report

2. If is_monorepo == true:
   ├─ Parse package name from artifact
   ├─ Move files to ./{package_name}/
   └─ SonarQube finds via sonar-project.properties

3. If is_monorepo == false:
   └─ Files stay in download_path (./)
```

### Coverage Path Remapping:
```ini
[paths]
source =
    src/
    ./src/
    */src/
    /Users/runner/work/*/src/   # macOS
    /home/runner/work/*/src/    # Linux
```

## _Testing_

Tested with:
- ✅ Monorepo with multiple packages (test-coverage-mcp)
- ✅ Sub-projects with no tests (codecov package)
- ✅ Cross-OS coverage (macOS + Linux runners)
- ✅ SonarQube multi-module scanning
- ✅ Codecov upload with coverage
- ✅ Graceful skip when no coverage

## _Migration Guide_

### For Monorepo Projects:
```yaml
# Add to your workflow
upload-sonarqube:
  uses: Chisanan232/GitHub-Action_Reusable_Workflows-Python/.github/workflows/rw_sonarqube_scan.yaml@master
  with:
    is_monorepo: true  # ← Add this
  secrets:
    sonar_token: ${{ secrets.SONAR_TOKEN }}
```

### For Single-Project Repos:
No changes needed! Everything works as before.

## _Commits_
- ✨ Add graceful skip for missing coverage artifacts in upload workflow
- 🔧 Check both XML and .coverage files before skipping upload
- 🔧 Check artifact existence before download to prevent errors
- ✨ Add monorepo support to SonarQube scan workflow
- ♻️ Simplify SonarQube monorepo support with pattern parsing
- 🔧 Only move coverage files for monorepo, restore download_path
- ♻️ Replace project_name with is_monorepo boolean parameter
- 🐛 Fix coverage path mismatch between macOS and Linux runners
- 🧹 Remove debug commands from organize coverage workflow