### PR TITLE
✨ feat: Make source folder configurable for coverage path remapping

### DIFF
--- a/.github/workflows/rw_organize_test_cov_reports.yaml
+++ b/.github/workflows/rw_organize_test_cov_reports.yaml
@@ -8,8 +8,10 @@
 #
 # Workflow input parameters:
 #     * test_type: The testing type. In generally, it only has 2 options: 'unit-test' and 'integration-test'.
+#     * project_name: Project identifier for monorepo (filters coverage artifacts by project). Leave empty for single-project repos.
 #     * run_with_python_version: The Python version you want to use in this workflow.
 #     * test_working_directory: The working directory for test running.
+#     * source_folder: Source code folder name for coverage path remapping (e.g., 'src', 'lib', 'app'). Default: 'src'.
 #
 # Workflow running output:
 #     No, but it would save the testing coverage reports (coverage.xml) to provide after-process to organize and record.
@@ -44,6 +46,11 @@ on:
         required: false
         type: string
         default: './'
+      source_folder:
+        description: "Source code folder name for coverage path remapping (e.g., 'src', 'lib', 'app'). Default: 'src'."
+        required: false
+        type: string
+        default: 'src'
 
 
 jobs:
@@ -118,7 +125,7 @@ jobs:
         run: |
           echo "Downloading coverage combine script..."
           curl -fsSL -o ./combine_coverage_reports.sh https://raw.githubusercontent.com/Chisanan232/GitHub-Action_Reusable_Workflows-Python/master/scripts/ci/combine_coverage_reports.sh
-          bash ./combine_coverage_reports.sh ${{ inputs.test_type }} .coverage.
+          bash ./combine_coverage_reports.sh ${{ inputs.test_type }} .coverage. ${{ inputs.source_folder }}
 
       - name: Upload testing coverage report (.coverage)
         if: steps.check_coverage.outputs.has_coverage == 'true'

--- a/scripts/ci/combine_coverage_reports.sh
+++ b/scripts/ci/combine_coverage_reports.sh
@@ -4,6 +4,7 @@ set -ex
 
 test_type=$1
 test_coverage_report_format=$2
+source_folder=${3:-src}  # Default to 'src' if not provided
 
 coveragedatafile=".coverage.$test_type"
 
@@ -17,16 +18,17 @@ fi
 # Get current working directory for path remapping
 CURRENT_DIR=$(pwd)
 echo "📂 Current directory: $CURRENT_DIR"
+echo "📁 Source folder: $source_folder"
 
 # Create .coveragerc to handle path remapping from macOS (/Users/) to Linux (/home/)
 cat > .coveragerc << EOF
 [paths]
 source =
-    src/
-    ./src/
-    */src/
-    /Users/runner/work/*/src/
-    /home/runner/work/*/src/
+    $source_folder/
+    ./$source_folder/
+    */$source_folder/
+    /Users/runner/work/*/$source_folder/
+    /home/runner/work/*/$source_folder/
 EOF
 
 echo "📝 Created .coveragerc for path remapping"


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

Fix hardcoded source folder path in coverage path remapping to support projects with different source code folder structures.

[//]: # (The summary what you did or your target.)
* ### Task summary:

    The `combine_coverage_reports.sh` script had a hardcoded `src/` path for coverage path remapping, which prevented it from working with projects that use different source folder names like `lib/`, `app/`, or custom folder structures. This change makes the source folder configurable while maintaining backward compatibility.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: N/A.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * Related to PR #153 (coverage handling improvements)

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **Before (Hardcoded)**:
    ```bash
    # combine_coverage_reports.sh
    cat > .coveragerc << EOF
    [paths]
    source =
        src/          # ← Always 'src', no flexibility
        ./src/
        */src/
    EOF
    ```
    
    **After (Configurable)**:
    ```bash
    # combine_coverage_reports.sh
    source_folder=${3:-src}  # ← Configurable with default
    
    cat > .coveragerc << EOF
    [paths]
    source =
        $source_folder/       # ← Dynamic based on parameter
        ./$source_folder/
        */$source_folder/
    EOF
    ```
    
    **Usage**:
    ```yaml
    # Default (src folder)
    uses: .../rw_organize_test_cov_reports.yaml@master
    with:
      test_type: all-test
      # source_folder defaults to 'src'
    
    # Custom folder
    uses: .../rw_organize_test_cov_reports.yaml@master
    with:
      test_type: all-test
      source_folder: lib  # ← Specify custom folder
    ```


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [x] 🍀 Improving something (maybe performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] ✍️ Command line interface
    * [x] 💼 Core feature
        * [x] ⚙️ Reusable workflow
        * [x] 🐍 Scripts
        * [ ] 🗃️ Configuration
    * [ ] 🎨 UI/UX (maybe command line interface, etc.)
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 End-to-end testing
    * [x] 📚 Documentation
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
* Additional description:
    - Affects `rw_organize_test_cov_reports.yaml` workflow
    - Affects `combine_coverage_reports.sh` script
    - **Backward compatible**: Existing workflows continue to work without changes
    - Projects using `src/` folder don't need to change anything
    - Projects with custom folders can now specify `source_folder` parameter


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

### Changes Made:

#### 1. **Shell Script** (`scripts/ci/combine_coverage_reports.sh`)
- Add `source_folder` as 3rd parameter with default value `src`
- Use parameter in `.coveragerc` path remapping configuration
- Support dynamic source folder paths for cross-OS compatibility
- Add logging to show which source folder is being used

#### 2. **Workflow** (`rw_organize_test_cov_reports.yaml`)
- Add new input parameter `source_folder`:
  - Type: `string`
  - Required: `false`
  - Default: `'src'`
  - Description: "Source code folder name for coverage path remapping (e.g., 'src', 'lib', 'app')"
- Update script call to pass `source_folder` parameter
- Update workflow documentation header

### Technical Details:

**Script Parameters**:
```bash
# combine_coverage_reports.sh
$1 = test_type              # e.g., 'unit-test', 'all-test'
$2 = coverage_report_format # e.g., '.coverage.'
$3 = source_folder          # e.g., 'src', 'lib', 'app' (default: 'src')
```

**Path Remapping**:
The script generates a `.coveragerc` file with dynamic paths:
```ini
[paths]
source =
    {source_folder}/
    ./{source_folder}/
    */{source_folder}/
    /Users/runner/work/*/{source_folder}/   # macOS
    /home/runner/work/*/{source_folder}/    # Linux
```

### Use Cases:

**1. Default behavior (src folder)**:
```yaml
uses: .../rw_organize_test_cov_reports.yaml@master
with:
  test_type: all-test
  # No source_folder needed - defaults to 'src'
```

**2. Projects with lib/ folder**:
```yaml
uses: .../rw_organize_test_cov_reports.yaml@master
with:
  test_type: all-test
  source_folder: lib
```

**3. Projects with app/ folder**:
```yaml
uses: .../rw_organize_test_cov_reports.yaml@master
with:
  test_type: all-test
  source_folder: app
```

**4. Projects with custom folder structure**:
```yaml
uses: .../rw_organize_test_cov_reports.yaml@master
with:
  test_type: all-test
  source_folder: my_package
```

### Benefits:

✅ **Flexible**: Works with any source folder structure  
✅ **Backward compatible**: No breaking changes - defaults to `src`  
✅ **Configurable**: Projects can specify their own folder name  
✅ **Cross-OS**: Maintains macOS/Linux path remapping  
✅ **Well-documented**: Clear parameter description and examples  

### Testing:

- ✅ Tested with default `src/` folder (existing behavior)
- ✅ Verified backward compatibility (no parameters needed)
- ✅ Confirmed script accepts 3rd parameter correctly
- ✅ Validated `.coveragerc` generation with custom folders

### Migration Guide:

**No migration needed!** This change is fully backward compatible.

- **Existing workflows**: Continue to work without any changes
- **New workflows**: Can optionally specify `source_folder` if needed
- **Projects with src/**: No action required
- **Projects with custom folders**: Add `source_folder: your_folder` parameter
