### PR TITLE
🐛 fix: Update coverage path patterns to handle nested monorepo paths

### DIFF
--- a/scripts/ci/combine_coverage_reports.sh
+++ b/scripts/ci/combine_coverage_reports.sh
@@ -27,8 +27,9 @@ source =
     $source_folder/
     ./$source_folder/
     */$source_folder/
-    /Users/runner/work/*/$source_folder/
-    /home/runner/work/*/$source_folder/
+    */*/$source_folder/
+    /Users/runner/work/**/$source_folder/
+    /home/runner/work/**/$source_folder/
 EOF
 
 echo "📝 Created .coveragerc for path remapping"


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix coverage path remapping patterns to support nested monorepo structures where packages are located multiple directory levels deep.

* ### Task tickets:

    * Task ID: N/A.
    * Relative PRs:
        * Related to monorepo coverage fixes

* ### Key point change:

    **Problem:**
    Coverage path remapping was failing for monorepo structures with nested paths like:
    ```
    /Users/runner/work/test-coverage-mcp/test-coverage-mcp/test-coverage-mcp-codecov/src/
    ```
    
    **Before:**
    ```bash
    source =
        src/
        ./src/
        */src/                              # Only matches 1 level
        /Users/runner/work/*/src/           # Only matches 1 level
        /home/runner/work/*/src/            # Only matches 1 level
    ```
    
    **After:**
    ```bash
    source =
        src/
        ./src/
        */src/                              # Matches 1 level
        */*/ src/                           # ← NEW: Matches 2 levels
        /Users/runner/work/**/$source_folder/   # ← FIXED: ** matches any depth
        /home/runner/work/**/$source_folder/    # ← FIXED: ** matches any depth
    ```

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
    * [x] 🍀 Improving something (code quality, reliability)
* Scopes:
    * [x] 💼 Core feature
        * [x] 🐍 Scripts
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
* Additional description:
    - Fixes "No source for code" errors in monorepo coverage reports
    - Backward compatible with existing single-repo projects
    - Uses `**` glob pattern for multi-level directory matching

## _Description_

### Changes Made:

**File:** `scripts/ci/combine_coverage_reports.sh`

1. **Added `*/*/$source_folder/` pattern** - Matches 2-level nested paths (e.g., `repo/package/src/`)

2. **Changed `/Users/runner/work/*/` to `/Users/runner/work/**/`** - The `**` pattern matches any number of directory levels, supporting deeply nested monorepo structures

3. **Changed `/home/runner/work/*/` to `/home/runner/work/**/`** - Same fix for Linux runners

### Why This Fix Was Needed:

The single `*` wildcard only matches **one directory level**, but monorepo structures often have paths like:
```
/Users/runner/work/[REPO]/[REPO]/[PACKAGE]/[SOURCE_FOLDER]/
                    ^      ^       ^         ^
                    |      |       |         |
                    1st    2nd     3rd       4th level
```

The old pattern `/Users/runner/work/*/src/` could only match:
```
/Users/runner/work/[ONE_LEVEL]/src/  ✅
/Users/runner/work/a/b/src/          ❌ (two levels)
```

The new pattern `/Users/runner/work/**/src/` matches:
```
/Users/runner/work/repo/src/                    ✅
/Users/runner/work/repo/package/src/            ✅
/Users/runner/work/repo/repo/package/src/       ✅ (monorepo case)
```

### Benefits:

✅ Fixes coverage path remapping for monorepo projects  
✅ Backward compatible with single-repo projects  
✅ Future-proof for any nesting depth  
✅ Resolves "No source for code" errors in CI workflows