### PR TITLE
⬆️ upgrade: Modernize Codecov integration with official action and org token support

### DIFF
--- a/.github/workflows/rw_upload_test_cov_report.yaml
+++ b/.github/workflows/rw_upload_test_cov_report.yaml
@@ -221,16 +221,15 @@ jobs:
 
       - name: Upload coverage report to Codecov https://codecov.io
         if: ${{ inputs.upload-to-codecov == true && steps.check_coverage.outputs.has_coverage == 'true' }}
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov \
-            -t ${{ secrets.codecov_token }} \
-            --file coverage_${{ inputs.test_type }}.xml \
-            --flags ${{ inputs.codecov_flags }} \
-            --env OS,PYTHON \
-            --name ${{ inputs.codecov_name }} \
-            --verbose
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.codecov_token }}
+          files: coverage_${{ inputs.test_type }}.xml
+          flags: ${{ inputs.codecov_flags }}
+          env_vars: OS,PYTHON
+          name: ${{ inputs.codecov_name }}
+          verbose: true
+          fail_ci_if_error: false
 
       - name: Install Python dependencies about tool of Coveralls
         if: ${{ inputs.upload-to-coveralls == true }}

--- a/.github/workflows/rw_upload_test_cov_report.yaml
+++ b/.github/workflows/rw_upload_test_cov_report.yaml
@@ -12,6 +12,7 @@
 #         * upload-to-codecov: If it's true, it would upload testing coverage report for Codecov (https://codecov.io).
 #         * codecov_flags: The flags of the testing coverage report for Codecov. This option would be required if 'upload-to-codecov' is true.
 #         * codecov_name: The name of the testing coverage report for Codecov. This option would be required if 'upload-to-codecov' is true.
+#         * codecov_slug: The repository slug for Codecov (format: owner/repo). Used when uploading with organization-wide tokens.
 #         * upload-to-coveralls: If it's true, it would upload testing coverage report for Coveralls (https://coveralls.io).
 #         * upload-to-codacy: If it's true, it would upload testing coverage report for Codacy (https://app.codacy.com/).
 #
@@ -66,6 +67,11 @@ on:
         default: ''
       codecov_name:
         description: "The name of the testing coverage report for Codecov. This option would be required if 'upload-to-codecov' is true."
+        type: string
+        required: false
+        default: ''
+      codecov_slug:
+        description: "The repository slug for Codecov (format: owner/repo). Used when uploading with organization-wide tokens."
         type: string
         required: false
         default: ''
@@ -228,6 +234,7 @@ jobs:
           flags: ${{ inputs.codecov_flags }}
           env_vars: OS,PYTHON
           name: ${{ inputs.codecov_name }}
+          slug: ${{ inputs.codecov_slug }}
           verbose: true
           fail_ci_if_error: false
 


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Modernize Codecov integration by replacing manual curl-based uploader with the official `codecov/codecov-action@v6` and add support for organization-wide tokens.

* ### Task tickets:

    * Task ID: N/A.
    * Relative PRs:
        * N/A.

* ### Key point change:

    **1. Replace manual Codecov uploader with official action:**
    
    **Before:**
    ```yaml
    - name: Upload coverage report to Codecov
      run: |
        curl -Os https://uploader.codecov.io/latest/linux/codecov
        chmod +x codecov
        ./codecov \
          -t ${{ secrets.codecov_token }} \
          --file coverage_${{ inputs.test_type }}.xml \
          --flags ${{ inputs.codecov_flags }} \
          --env OS,PYTHON \
          --name ${{ inputs.codecov_name }} \
          --verbose
    ```
    
    **After:**
    ```yaml
    - name: Upload coverage report to Codecov
      uses: codecov/codecov-action@v6
      with:
        token: ${{ secrets.codecov_token }}
        files: coverage_${{ inputs.test_type }}.xml
        flags: ${{ inputs.codecov_flags }}
        env_vars: OS,PYTHON
        name: ${{ inputs.codecov_name }}
        slug: ${{ inputs.codecov_slug }}
        verbose: true
        fail_ci_if_error: false
    ```
    
    **2. Add organization-wide token support:**
    
    New input parameter:
    ```yaml
    codecov_slug:
      description: "The repository slug for Codecov (format: owner/repo). Used when uploading with organization-wide tokens."
      type: string
      required: false
      default: ''
    ```

## _Effecting Scope_

* Action Types:
    * [x] ⬆️ Upgrading dependencies
    * [x] ✨ Adding new feature
    * [x] 🍀 Improving something (reliability, security, maintainability)
* Scopes:
    * [x] 💼 Core feature
        * [x] ⚙️ Reusable workflow
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
    * [x] 🧪 Testing
        * [x] 📊 Coverage reporting
* Additional description:
    - Modernizes Codecov upload mechanism
    - Enables organization-wide token usage
    - Improves reliability and security
    - Backward compatible with existing workflows

## _Description_

### Changes Made:

**File:** `.github/workflows/rw_upload_test_cov_report.yaml`

**Change 1: Replace manual uploader with official action**
- Removed manual curl download and execution
- Use `codecov/codecov-action@v6` instead
- All parameters correctly mapped
- Added `fail_ci_if_error: false` to prevent CI failures on upload issues

**Change 2: Add codecov_slug parameter**
- New input parameter for repository slug
- Format: `owner/repo` (e.g., `Chisanan232/my-project`)
- Enables organization-wide token usage
- Optional parameter (backward compatible)

### Benefits:

✅ **Better Reliability** - Official action with automatic retries  
✅ **Improved Security** - No manual script download/execution  
✅ **Easier Maintenance** - Cleaner workflow code  
✅ **More Flexibility** - Support for organization-wide tokens  
✅ **Backward Compatible** - Existing workflows work without changes

### Usage Examples:

**Example 1: Per-repository token (existing usage - no changes needed):**
```yaml
uses: .../rw_upload_test_cov_report.yaml@master
with:
  upload-to-codecov: true
  codecov_flags: 'unit-tests'
  codecov_name: 'Unit Test Coverage'
secrets:
  codecov_token: ${{ secrets.CODECOV_TOKEN }}
```

**Example 2: Organization-wide token (new capability):**
```yaml
uses: .../rw_upload_test_cov_report.yaml@master
with:
  upload-to-codecov: true
  codecov_slug: 'Chisanan232/my-project'
  codecov_flags: 'unit-tests'
  codecov_name: 'Unit Test Coverage'
secrets:
  codecov_token: ${{ secrets.CODECOV_ORG_TOKEN }}
```